### PR TITLE
Mention KDE Plasma as being themable

### DIFF
--- a/themes.md
+++ b/themes.md
@@ -16,6 +16,8 @@ Linux is a kernel, and has nothing to do with themes. While some desktop environ
 
   - There are specs for _icon_ and _sound_ themes, but even these are both incomplete and outdated.
 
+- [KDE Plasma][https://kde.org/plasma-desktop] officially supports themes, color schemes, accent colors, and FreeDesktop-compatible icon themes, as applied to both Plasma itself and apps using the Qt and GTK toolkits.
+
 - Several app developers are calling for Linux distributions and downstreams to [stop theming their apps](https://stopthemingmy.app/).
 
 - [elementary OS](https://elementary.io) does not support user themes, and consequently supports unique [branding and in-app theming](https://medium.com/elementaryos/developer-tips-branding-your-app-a57cb44d31d3) capabilities.


### PR DESCRIPTION
Plasma is the most prominent example of an environment that does explicitly support theming, so it probably ought to be mentioned on this page. Otherwise it feels like a rather glaring omission.